### PR TITLE
preventing error if compiler.options doesn't exist

### DIFF
--- a/lib/compilerAdapter.js
+++ b/lib/compilerAdapter.js
@@ -102,7 +102,7 @@ CompilerAdapter.prototype.watch = function(file, callback) {
         watcher;
 
     if (compiler) {
-        var watchDelay = compiler.options.watchDelay || 200;
+        var watchDelay = compiler.options && compiler.options.watchDelay || 200;
 
         watcher = compiler.watcher;
 


### PR DESCRIPTION
I'm getting an error with my current configuration layout.

webpack.config.js manifest is ok (webpack is working fine with it) version 1.8.5

(https://cloud.githubusercontent.com/assets/511721/7333235/9f614c24-eb67-11e4-87b4-65e1c67f3e49.png)

